### PR TITLE
Always hide print statements from students

### DIFF
--- a/e2xgradingtools/decorators.py
+++ b/e2xgradingtools/decorators.py
@@ -85,6 +85,14 @@ def test_asserts(points):
         n_passed = "e2x_n_passed"
         n_failed = "e2x_n_failed"
 
+        updated.body[0].body.insert(
+            0,
+            ast.ImportFrom(
+                module="e2xgradingtools.utils",
+                names=[ast.alias(name="HiddenPrints", asname=None)],
+                level=0,
+            ),
+        )
         updated.body[0].body.insert(0, ast.parse(f"{n_passed} = 0").body[0])
         updated.body[0].body.insert(0, ast.parse(f"{n_failed} = 0").body[0])
         updated.body[0].body.insert(


### PR DESCRIPTION
Previously when using the `@test_asserts(points)` decorator, student prints where shown in the output of the test, enabling cheating. Now all print statements by students are suppressed.