### PR TITLE
Add comment to comparator

### DIFF
--- a/e2xgradingtools/comparators.py
+++ b/e2xgradingtools/comparators.py
@@ -7,5 +7,9 @@ def compare_strings(result, target):
 
 def compare_numbers(result, target):
     abs_error = abs(result - target)
-    rel_error = abs(abs_error / target) if target else 0
+    if target != 0:
+        rel_error = abs(abs_error / target)
+    else:
+        # Avoid division by zero
+        rel_error = 0
     return abs_error, rel_error


### PR DESCRIPTION
Make it clearer why we return a relative error of 0 if the target is 0 in `compare_numbers`.